### PR TITLE
Adjust TOC header underline width

### DIFF
--- a/luxry_antifund_fullsite/assets/css/style.css
+++ b/luxry_antifund_fullsite/assets/css/style.css
@@ -788,7 +788,7 @@ section {
   line-height: 1.5;
   transition: color 0.2s ease;
 
-  display: inline-block;
+  display: inline;
   border-bottom: 1px solid #e9ecef;
 
   padding-bottom: 4px;


### PR DESCRIPTION
Adjust table of contents link display to ensure underlines end at text width.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-490b425a-f9c0-44c6-b6d8-b03808242cb1) · [Cursor](https://cursor.com/background-agent?bcId=bc-490b425a-f9c0-44c6-b6d8-b03808242cb1)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)