### PR TITLE
Adjust TOC item underline

### DIFF
--- a/luxry_antifund_fullsite/assets/css/style.css
+++ b/luxry_antifund_fullsite/assets/css/style.css
@@ -783,20 +783,21 @@ section {
 
 .toc-list a {
   color: #333;
-  text-decoration: none;
+  text-decoration: underline;
+  text-decoration-color: #e9ecef;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 4px;
   font-size: 15px;
   line-height: 1.5;
-  transition: color 0.2s ease;
+  transition: color 0.2s ease, text-decoration-color 0.2s ease;
 
-  display: inline-block;
-  border-bottom: 1px solid #e9ecef;
-
-  padding-bottom: 4px;
+  display: block;
   margin-bottom: 8px;
 }
 
 .toc-list a:hover {
   color: #917434;
+  text-decoration-color: #917434;
 }
 
 /* Team member styling */


### PR DESCRIPTION
Adjust TOC item underline styling to ensure it only extends to the end of the text, not the full width of the container.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-3efc684d-39ab-44f4-a121-ed0ad0408b92) · [Cursor](https://cursor.com/background-agent?bcId=bc-3efc684d-39ab-44f4-a121-ed0ad0408b92)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)